### PR TITLE
TCP Port support

### DIFF
--- a/pycsco/nxos/device.py
+++ b/pycsco/nxos/device.py
@@ -49,7 +49,8 @@ class Device():
                  username='cisco',
                  password='cisco',
                  ip='192.168.200.50',
-                 protocol='http'):
+                 protocol='http',
+                 port=None):
 
         if protocol not in ('http', 'https'):
             raise ValueError('protocol must be http or https')
@@ -58,8 +59,12 @@ class Device():
         self.password = password
         self.ip = ip
         self.protocol = protocol
+        self.port = port
         self.sw1 = NXAPI()
-        self.sw1.set_target_url('%s://%s/ins' % (self.protocol, self.ip))
+        if self.port is not None:
+            self.sw1.set_target_url('%s://%s:%s/ins' % (self.protocol, self.ip, self.port))
+        else:    
+            self.sw1.set_target_url('%s://%s/ins' % (self.protocol, self.ip))
         self.sw1.set_username(self.username)
         self.sw1.set_password(self.password)
 

--- a/pycsco/nxos/nxapi.py
+++ b/pycsco/nxos/nxapi.py
@@ -59,7 +59,7 @@ class HTTPSConnection(HTTPConnection):
                                     ssl_version=ssl.PROTOCOL_SSLv3)
 
 
-httplib.HTTPSConnection = HTTPSConnection
+#httplib.HTTPSConnection = HTTPSConnection
 
 
 class RequestMsg:

--- a/pycsco/nxos/nxapi.py
+++ b/pycsco/nxos/nxapi.py
@@ -58,7 +58,16 @@ class HTTPSConnection(HTTPConnection):
                                     self.cert_file,
                                     ssl_version=ssl.PROTOCOL_SSLv3)
 
-
+#
+# Many changes to httplib were made around Python 2.6/2.7 and this monkey
+# patch breaks the code. I have not been able to figure out why the
+# originators of this code felt it necessary to add the ssl_version variable,
+# but everything seems to be working fine without it. The variable is not
+# referenced anywhere in the entire pycsco code tree. To avoid further
+# problems in the future the monkey patch has been disabled by commenting the
+# line below. The entire HTTPSConnection class should be removed sometime in
+# the future. // jonas@stenling.se
+#
 #httplib.HTTPSConnection = HTTPSConnection
 
 


### PR DESCRIPTION
This PR adds support to connect to the device on a user specified tcp port instead. If you instantiate the `Device` class with the optional `port` argument connections to the device will be made to the port number supplied.

This change is necessary due to Nexus 5k, 6k and 7k not supporting https NXAPI on tcp port 443. Response from TAC:

> This is the default behavior of nexus switches.
> This port number is blocked by default in Nexus platform for nxapi. There is a known documentation >bug for this already.
> https://tools.cisco.com/bugsearch/bug/CSCuw39988/?reffering_site=dumpcr
> 
> Reason:
> Seems to be an internal limitation where port 443 is blocked for security reasons
> 
> Workaround:
> Use different port other than 443. (You have already tried that)
> 
> Future plan for integration:
> I found the following statement from another bug: CSCus72962 (Employee visible bug)
> “there is no plan to open default tcp port 443 on these platforms”
