### PR TITLE
Update nxapi_lib.py

### DIFF
--- a/pycsco/nxos/utils/nxapi_lib.py
+++ b/pycsco/nxos/utils/nxapi_lib.py
@@ -188,6 +188,8 @@ def interface_range_to_list(interfaces):
             # Ethernet186/1/1-5
             if '/' in each:
                 if_name, _, if_range = each.rpartition('/')
+                if_range = if_range.replace("'","")
+                if_range = if_range.replace("]","")
                 low = int(if_range.split('-')[0])
                 high = int(if_range.split('-')[1])
                 for num in range(low, high+1):


### PR DESCRIPTION
Quick fix needed to support what seems like a "ton of fex ports"
- if_range = if_range.replace("'","")
  --ValueError: invalid literal for int() with base 10: "48'"
- if_range = if_range.replace("]","")
  --ValueError: invalid literal for int() with base 10: '48]'
  ---Results: {'uptime': -1, 'vendor': u'Cisco', 'hostname':
